### PR TITLE
Setup CD to push a Docker image to the DockerHub

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,7 +9,6 @@ jobs:
   push-docker-image:
     runs-on: ubuntu-latest
     steps:
-    steps:
       - uses: actions/checkout@v2
       - name: Set Release version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,4 +27,4 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          tags: culturale-api:latest
+          tags: culturale/culturale-api:latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,14 +2,21 @@ name: CD
 
 on:
   push:
-    branches:
-      - 'main'
-      - 'setup/CD'
+    tags:
+      - 'v*.*.*'
 
 jobs:
-  docker:
+  push-docker-image:
     runs-on: ubuntu-latest
     steps:
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set Release version
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Test
+        run: |
+          echo $RELEASE_VERSION
+          echo ${{ env.RELEASE_VERSION }}
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -27,4 +34,4 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          tags: culturale/culturale-api:latest
+          tags: culturale/culturale-api:${{env.RELEASE_VERSION}}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,30 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'setup/CD'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: culturale-api:latest


### PR DESCRIPTION
# Description

## Context

We were not releasing at any point using CD yet. We needed to generate Docker images such as the one used in local and push them to the Docker Hub.

## Goal

Update CD to trigger a job so a Docker image is built and pushed to the Docker Hub

https://hub.docker.com/r/culturale/culturale-api
